### PR TITLE
handle django_mongoengine ObjectIdField

### DIFF
--- a/rest_framework_mongoengine/serializers.py
+++ b/rest_framework_mongoengine/serializers.py
@@ -2,6 +2,7 @@ import copy
 import warnings
 from collections import OrderedDict, namedtuple
 
+from django_mongoengine.fields import ObjectIdField as dme_ObjectIdField
 from mongoengine import fields as me_fields
 from mongoengine.errors import ValidationError as me_ValidationError
 from rest_framework import fields as drf_fields
@@ -124,7 +125,8 @@ class DocumentSerializer(serializers.ModelSerializer):
         me_fields.GeoPointField: drfm_fields.GeoPointField,
         me_fields.GeoJsonBaseField: drfm_fields.GeoJSONField,
         me_fields.DynamicField: drfm_fields.DynamicField,
-        me_fields.BaseField: drfm_fields.DocumentField
+        me_fields.BaseField: drfm_fields.DocumentField,
+        dme_ObjectIdField: drfm_fields.ObjectIdField  # New
     }
 
     # induct failure if they occasionally used somewhere


### PR DESCRIPTION
Handle `django_mongoengine.fields.ObjectIdField` (missing from `serializer_field_mapping)



---
# Notes

NOTE: `rest_framework_mongoengine` depends on `django_rest_framework_mongoengine`?

```
(venv) [vagrant@edge code]$ pip uninstall django-rest-framework-mongoengine
Found existing installation: django-rest-framework-mongoengine 3.4.1
Uninstalling django-rest-framework-mongoengine-3.4.1:
  Would remove:
    /home/vagrant/code/venv/lib/python3.8/site-packages/django_rest_framework_mongoengine-3.4.1-py3.8.egg-info
    /home/vagrant/code/venv/lib/python3.8/site-packages/rest_framework_mongoengine/*
Proceed (Y/n)? y
  Successfully uninstalled django-rest-framework-mongoengine-3.4.1
(venv) [vagrant@edge code]$
```

---


Why zero targets built?
```
(venv) [vagrant@edge code]$ VENV=cony_venv cony_venv/bin/python cony build src/python/soltra/edge/org:org
0 target(s) built
```

---

Which name is it?
 1. `python:django_rest_framework_mongoengine`
 2. `python:django-rest-framework-mongoengine`
 3. `python:rest-framework-mongoengine`
 4. `python:framework-mongoengine`

```
(venv) [vagrant@edge code]$ make build
rm -rf dist
rm -rf dist-rpm
rm -rf /home/vagrant/code/edge-artifacts
rm -rf /home/vagrant/code/edge-vm-tools-artifacts
testing yarn version installed...
yarn
yarn install v1.22.19
[1/4] Resolving packages...
success Already up-to-date.
Done in 1.38s.
touch node_modules/ready
build: setting plugin versions to 3.5.1.47.gbfbcc6b...
sed -i 's@"version.*@"version": "3.5.1.47.gbfbcc6b",@' src/python/edge_plugin/*/INFO.json
git submodule update --init
build: running Edge core build, version: 3.5.1.47.gbfbcc6b...
build: built Edge will be located:  /home/vagrant/code/edge-artifacts...
npx browserslist@latest --update-db
npx: installed 7 in 3.839s
Latest version:     1.0.30001420
Installed version:  1.0.30001420
caniuse-lite is up to date
caniuse-lite has been successfully updated

No target browser changes
VENV=cony_venv cony_venv/bin/python cony build src/python/soltra/edge
    unhandled exception while building src/python/soltra/edge:edge
    target "3rdparty/python:django_rest_framework_mongoengine" not found, needed by "src/python/soltra/edge/org:org"
make: *** [build-edge] Error 1
```